### PR TITLE
Add F1-Schedule telegram bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# telegram-f1
+# F1-Schedule Bot
+
+This project implements a simple Telegram bot written in TypeScript that
+displays the Formula 1 calendar. The bot responds to two text commands:
+
+* `full calendar` – shows the full race schedule for the current season.
+* `next race` – shows information about the upcoming race.
+
+All times are converted to Israel time (Asia/Jerusalem).
+
+## Development
+
+Install the dependencies and compile the TypeScript sources:
+
+```bash
+npm install
+npm run build
+```
+
+Run the bot by providing a Telegram bot token:
+
+```bash
+BOT_TOKEN=your_token_here npm start
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "f1-schedule-bot",
+  "version": "1.0.0",
+  "description": "Telegram bot showing F1 race schedule",
+  "main": "dist/bot.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/bot.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "moment-timezone": "^0.5.43",
+    "node-telegram-bot-api": "^0.61.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4"
+  }
+}

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,90 @@
+import TelegramBot from 'node-telegram-bot-api';
+import axios from 'axios';
+import moment from 'moment-timezone';
+
+const token = process.env.BOT_TOKEN;
+if (!token) {
+  throw new Error('BOT_TOKEN environment variable is required');
+}
+
+const bot = new TelegramBot(token, { polling: true });
+
+bot.onText(/\/start/, msg => {
+  const chatId = msg.chat.id;
+  bot.sendMessage(
+    chatId,
+    'Welcome to F1-Schedule!\nSend "full calendar" or "next race" to get information.'
+  );
+});
+
+bot.on('message', async msg => {
+  const chatId = msg.chat.id;
+  const text = msg.text?.toLowerCase();
+
+  if (text === 'full calendar') {
+    try {
+      const races = await fetchFullCalendar();
+      const message = races.map(formatRace).join('\n\n');
+      bot.sendMessage(chatId, message, { parse_mode: 'Markdown' });
+    } catch (err) {
+      bot.sendMessage(chatId, 'Failed to load calendar');
+    }
+  } else if (text === 'next race') {
+    try {
+      const races = await fetchNextRace();
+      const message = races.map(formatRace).join('\n\n');
+      bot.sendMessage(chatId, message, { parse_mode: 'Markdown' });
+    } catch (err) {
+      bot.sendMessage(chatId, 'Failed to load next race');
+    }
+  }
+});
+
+interface Race {
+  raceName: string;
+  Circuit: {
+    circuitName: string;
+  };
+  date: string;
+  time?: string;
+  Qualifying?: { date: string; time?: string };
+  Sprint?: { date: string; time?: string };
+}
+
+async function fetchFullCalendar(): Promise<Race[]> {
+  const url = 'https://ergast.com/api/f1/current.json';
+  const res = await axios.get(url);
+  return res.data.MRData.RaceTable.Races as Race[];
+}
+
+async function fetchNextRace(): Promise<Race[]> {
+  const url = 'https://ergast.com/api/f1/current/next.json';
+  const res = await axios.get(url);
+  return res.data.MRData.RaceTable.Races as Race[];
+}
+
+function formatRace(race: Race): string {
+  const jerusalem = 'Asia/Jerusalem';
+  const raceDate = convertToTZ(race.date, race.time, jerusalem);
+  const qual = race.Qualifying
+    ? convertToTZ(race.Qualifying.date, race.Qualifying.time, jerusalem)
+    : undefined;
+  const sprint = race.Sprint
+    ? convertToTZ(race.Sprint.date, race.Sprint.time, jerusalem)
+    : undefined;
+
+  let msg = `*${race.raceName}*\nCircuit: ${race.Circuit.circuitName}\nRace: ${raceDate}`;
+  if (qual) {
+    msg += `\nQualifying: ${qual}`;
+  }
+  if (sprint) {
+    msg += `\nSprint: ${sprint}`;
+  }
+  return msg;
+}
+
+function convertToTZ(date: string, time = '00:00:00Z', tz: string): string {
+  const m = moment.tz(`${date}T${time}`, tz);
+  return m.format('YYYY-MM-DD HH:mm z');
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a Node.js/TypeScript telegram bot that reports F1 race times in Israel timezone
- document how to build and run the bot
- add project metadata and ignore generated files

## Testing
- `npm run build` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_685ae286c4348325adcccc6d4df52d7d