### PR TITLE
Add Jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/bot.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/bot.js"
+    "start": "node dist/bot.js",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^1.6.0",
@@ -14,6 +15,9 @@
   },
   "devDependencies": {
     "typescript": "^5.0.4",
-    "@types/node-telegram-bot-api": "^0.61.0"
+    "@types/node-telegram-bot-api": "^0.61.0",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/__tests__/bot.test.ts
+++ b/src/__tests__/bot.test.ts
@@ -1,0 +1,27 @@
+import { formatRace, convertToTZ } from '../bot';
+
+describe('convertToTZ', () => {
+  it('converts UTC time to Asia/Jerusalem', () => {
+    const result = convertToTZ('2023-05-07', '13:00:00Z', 'Asia/Jerusalem');
+    expect(result).toBe('2023-05-07 16:00 IDT');
+  });
+});
+
+describe('formatRace', () => {
+  it('formats race information', () => {
+    const race = {
+      raceName: 'Test GP',
+      Circuit: { circuitName: 'Test Circuit' },
+      date: '2023-05-07',
+      time: '13:00:00Z',
+      Qualifying: { date: '2023-05-06', time: '13:00:00Z' },
+      Sprint: { date: '2023-05-06', time: '09:00:00Z' },
+    } as any;
+    const msg = formatRace(race);
+    expect(msg).toContain('*Test GP*');
+    expect(msg).toContain('Circuit: Test Circuit');
+    expect(msg).toContain('Race: 2023-05-07 16:00 IDT');
+    expect(msg).toContain('Qualifying: 2023-05-06 16:00 IDT');
+    expect(msg).toContain('Sprint: 2023-05-06 12:00 IDT');
+  });
+});

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -88,3 +88,5 @@ function convertToTZ(date: string, time = '00:00:00Z', tz: string): string {
   return m.format('YYYY-MM-DD HH:mm z');
 }
 
+export { formatRace, convertToTZ };
+


### PR DESCRIPTION
## Summary
- export helper functions for testing
- configure Jest and add test script
- test convertToTZ and formatRace

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae59972708325a5c9a6fbef15b59a