### PR TITLE
Add logging and refactor startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "f1-schedule-bot",
   "version": "1.0.0",
   "description": "Telegram bot showing F1 race schedule",
-  "main": "dist/bot.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/bot.js",
+    "start": "node dist/index.js",
     "test": "jest"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+import { startBot } from './bot';
+
+startBot();


### PR DESCRIPTION
## Summary
- log startup success/failure
- log each incoming message and sent response
- export `startBot` and create `index.ts` entrypoint
- adjust package.json to use new entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ba4de7dd083259de336a3cb4c69be