### PR TITLE
Support updated OpenF1 session format

### DIFF
--- a/src/__tests__/bot.test.ts
+++ b/src/__tests__/bot.test.ts
@@ -14,6 +14,7 @@ describe('formatRace', () => {
       Circuit: { circuitName: 'Test Circuit' },
       date: '2023-05-07',
       time: '13:00:00Z',
+      startTime: '2023-05-07T13:00:00Z',
       Qualifying: { date: '2023-05-06', time: '13:00:00Z' },
       Sprint: { date: '2023-05-06', time: '09:00:00Z' },
     } as any;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -62,12 +62,15 @@ interface Race {
   };
   date: string;
   time?: string;
+  startTime: string;
   Qualifying?: { date: string; time?: string };
   Sprint?: { date: string; time?: string };
 }
 
 interface OpenF1Session {
-  meeting_name: string;
+  meeting_name?: string;
+  location?: string;
+  country_name?: string;
   circuit_short_name: string;
   session_name: string;
   date_start: string;
@@ -83,17 +86,22 @@ async function fetchFullCalendar(): Promise<Race[]> {
 async function fetchNextRace(): Promise<Race[]> {
   const races = await fetchFullCalendar();
   const now = new Date();
-  const next = races.find(r => new Date(`${r.date}T${r.time ?? '00:00:00Z'}`) > now);
+  const next = races.find(r => new Date(r.startTime) > now);
   return next ? [next] : [];
 }
 
 function mapSessionToRace(session: OpenF1Session): Race {
   const [date, time] = session.date_start.split('T');
+  const raceName =
+    session.meeting_name ??
+    (session.location ? `${session.location} GP` : session.country_name ?? '');
+
   return {
-    raceName: session.meeting_name,
+    raceName,
     Circuit: { circuitName: session.circuit_short_name },
     date,
     time,
+    startTime: session.date_start,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `startTime` field to `Race`
- compute `raceName` from location/country when `meeting_name` absent
- pick next race using the new `startTime`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685be32fec48832599a0a708ad46e50a