### PR TITLE
Add driver and team standings commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # F1-Schedule Bot
 
 This project implements a simple Telegram bot written in TypeScript that
-displays the Formula 1 calendar. The bot responds to two text commands:
+displays the Formula 1 calendar and standings. The bot responds to the
+following text commands:
 
 * `full calendar` – shows the full race schedule for the current season.
 * `next race` – shows information about the upcoming race.
+* `driver standings` – current driver championship standings.
+* `team standings` – current constructor championship standings.
 
 All times are converted to Israel time (Asia/Jerusalem).
 


### PR DESCRIPTION
## Summary
- extend bot features with driver and constructor standings commands
- update README with new commands

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685beee1c5b483259bf4894db4cc4d4e