### PR TITLE
Update commands to slash format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This project implements a simple Telegram bot written in TypeScript that
 displays the Formula 1 calendar and standings. The bot responds to the
 following text commands:
 
-* `full` – shows the full race schedule for the current season.
-* `next` – shows information about the upcoming race.
-* `drivers` – current driver championship standings.
-* `teams` – current constructor championship standings.
+* `/full` – shows the full race schedule for the current season.
+* `/next` – shows information about the upcoming race.
+* `/drivers` – current driver championship standings.
+* `/teams` – current constructor championship standings.
 
 All times are converted to Israel time (Asia/Jerusalem).
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -18,7 +18,7 @@ function startBot(): TelegramBot {
     const chatId = msg.chat.id;
     bot.sendMessage(
       chatId,
-      'Welcome to F1-Schedule!\nSend "full", "next", "drivers" or "teams" to get information.'
+      'Welcome to F1-Schedule!\nSend "/full", "/next", "/drivers" or "/teams" to get information.'
     );
   });
 
@@ -28,7 +28,7 @@ function startBot(): TelegramBot {
 
     console.log(`Received message from ${chatId}: ${text}`);
 
-    if (text === 'full') {
+    if (text === '/full') {
       try {
         const races = await fetchFullCalendar();
         const message = races.map(formatRace).join('\n\n');
@@ -38,7 +38,7 @@ function startBot(): TelegramBot {
         console.error('Failed to load calendar', err);
         bot.sendMessage(chatId, 'Failed to load calendar');
       }
-    } else if (text === 'next') {
+    } else if (text === '/next') {
       try {
         const races = await fetchNextRace();
         if (races.length === 0) {
@@ -52,7 +52,7 @@ function startBot(): TelegramBot {
         console.error('Failed to load next race', err);
         bot.sendMessage(chatId, 'Failed to load next race');
       }
-    } else if (text === 'drivers') {
+    } else if (text === '/drivers') {
       try {
         const standings = await fetchDriverStandings();
         const message = standings.join('\n');
@@ -62,7 +62,7 @@ function startBot(): TelegramBot {
         console.error('Failed to load driver standings', err);
         bot.sendMessage(chatId, 'Failed to load driver standings');
       }
-    } else if (text === 'teams') {
+    } else if (text === '/teams') {
       try {
         const standings = await fetchConstructorStandings();
         const message = standings.join('\n');


### PR DESCRIPTION
## Summary
- update README to show slash-prefixed bot commands
- update bot logic to handle '/full', '/next', '/drivers' and '/teams'

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c00fe4cb88325b93d9e703a6e68f1